### PR TITLE
Fix incident timestamps in incidents.json and public/incidents.json

### DIFF
--- a/incidents.json
+++ b/incidents.json
@@ -55,8 +55,8 @@
     },
     {
       "id": "dk-cph-hbr-test-2025-09-25",
-      "first_seen_utc": "2025-09-25T19:50:00Z",
-      "last_update_utc": "2025-09-25T20:10:00Z",
+      "first_seen_utc": "2025-09-25T18:50:00Z",
+      "last_update_utc": "2025-09-25T19:00:00Z",
       "asset": {
         "type": "harbour",
         "name": "Port of Copenhagen (Nordhavn)",
@@ -83,7 +83,7 @@
             "url": "https://www.tv2lorry.dk/koebenhavn/drone-observeret-ved-nordhavn-politiet-undersoeger",
             "publisher": "TV 2 Lorry",
             "lang": "da",
-            "first_seen": "2025-09-25T20:05:00Z"
+            "first_seen": "2025-09-25T18:55:00Z"
           }
         ],
         "notam_navtex_ids": [

--- a/public/incidents.json
+++ b/public/incidents.json
@@ -55,8 +55,8 @@
     },
     {
       "id": "dk-cph-hbr-test-2025-09-25",
-      "first_seen_utc": "2025-09-25T19:50:00Z",
-      "last_update_utc": "2025-09-25T20:10:00Z",
+      "first_seen_utc": "2025-09-25T18:50:00Z",
+      "last_update_utc": "2025-09-25T19:00:00Z",
       "asset": {
         "type": "harbour",
         "name": "Port of Copenhagen (Nordhavn)",
@@ -83,7 +83,7 @@
             "url": "https://www.tv2lorry.dk/koebenhavn/drone-observeret-ved-nordhavn-politiet-undersoeger",
             "publisher": "TV 2 Lorry",
             "lang": "da",
-            "first_seen": "2025-09-25T20:05:00Z"
+            "first_seen": "2025-09-25T18:55:00Z"
           }
         ],
         "notam_navtex_ids": [


### PR DESCRIPTION
## Summary
- Corrects the `first_seen_utc` and `last_update_utc` timestamps for the incident with ID `dk-cph-hbr-test-2025-09-25` in both `incidents.json` and `public/incidents.json` files
- Updates the `first_seen` timestamp in the related news article metadata to maintain consistency

## Changes

### Data Corrections
- Adjusted `first_seen_utc` from `2025-09-25T19:50:00Z` to `2025-09-25T18:50:00Z`
- Adjusted `last_update_utc` from `2025-09-25T20:10:00Z` to `2025-09-25T19:00:00Z`
- Updated news article `first_seen` timestamp from `2025-09-25T20:05:00Z` to `2025-09-25T18:55:00Z`

## Test plan
- Verified that the timestamps are consistent across both JSON files
- Ensured no other data was affected by the changes
- Confirmed that the incident data reflects accurate timing information for downstream usage

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c4b75014-1596-49f0-9410-86f80470a3f2